### PR TITLE
Fixing outdated names and links + spacefish prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ To contribute, fork this repository, add your amazing nugget and send a PR.
 
 ## Plugin Managers & Frameworks
 
-* [Fisherman](https://github.com/fisherman/fisherman) - The fish-shell plugin manager.
+* [Fisher](https://github.com/jorgebucaran/fisher) - The fish-shell plugin manager.
 * [Oh My Fish!](https://github.com/oh-my-fish/oh-my-fish) - The fish-shell framework.
 
 ## Plugins
 
 * [rodrigobdz/fish-apple-touchbar](https://github.com/rodrigobdz/fish-apple-touchbar) - Customize your Touch Bar in iTerm2 using fish.
 * [edc/bass](https://github.com/edc/bass) - Make Bash utilities usable in fish.
-* [fisherman/fishtape](https://github.com/fisherman/fishtape) - TAP producing test runner.
-* [fisherman/fnm](https://github.com/fisherman/fnm) - Node.js version manager.
-* [fisherman/getopts](https://github.com/fisherman/getopts) - Command line options parser.
+* [jorgebucaran/fishtape](https://github.com/jorgebucaran/fishtape) - TAP producing test runner.
+* [jorgebucaran/fnm](https://github.com/jorgebucaran/fnm) - Node.js version manager.
+* [jorgebucaran/getopts](https://github.com/jorgebucaran/fishopts) - Command line options parser.
 * [laughedelic/pisces](https://github.com/laughedelic/pisces) - Autocloses parentheses, braces, quotes and other paired symbols.
-* [fisherman/shark](https://github.com/fisherman/shark) - Sparkline generator, inspired by @holman's Spark.
-* [fisherman/z](https://github.com/fisherman/z) - Pure-fish z directory jumping.
+* [jorgebucaran/shark](https://github.com/jorgebucaran/shark) - Sparkline generator, inspired by @holman's Spark.
+* [jethrokuan/z](https://github.com/jethrokuan/z) - Pure-fish z directory jumping.
 * [smh/base16-shell-fish](https://github.com/smh/base16-shell-fish) - Fast and easy fisherman plugin for switching your [base16-shell theme](https://github.com/chriskempson/base16-shell)
 
 **Various links with plugin lists:**

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ To contribute, fork this repository, add your amazing nugget and send a PR.
 
 ## Simple Prompts
 
+* [matchai/spacefish](https://github.com/matchai/spacefish) - A Fish Shell prompt for Astronauts.
 * [fisherman/metro](https://github.com/fisherman/metro) - Powerline prompt optimized for speed and space.
 * [rafaelrinaldi/pure](https://github.com/rafaelrinaldi/pure) - Port of the <samp>pure</samp> ZSH prompt to Fish.
 * [oh-my-fish/theme-bobthefish](https://github.com/oh-my-fish/theme-bobthefish) - A Powerline-style, Git-aware fish theme optimized for awesome.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ To contribute, fork this repository, add your amazing nugget and send a PR.
 ## Simple Prompts
 
 * [matchai/spacefish](https://github.com/matchai/spacefish) - A Fish Shell prompt for Astronauts.
-* [fisherman/metro](https://github.com/fisherman/metro) - Powerline prompt optimized for speed and space.
+* [jorgebucaran/fish-metro](https://github.com/jorgebucaran/fish-metro) - Powerline prompt optimized for speed and space.
 * [rafaelrinaldi/pure](https://github.com/rafaelrinaldi/pure) - Port of the <samp>pure</samp> ZSH prompt to Fish.
 * [oh-my-fish/theme-bobthefish](https://github.com/oh-my-fish/theme-bobthefish) - A Powerline-style, Git-aware fish theme optimized for awesome.
 * [oh-my-fish/theme-cbjohnson](https://github.com/oh-my-fish/theme-cbjohnson)
-* [fisherman/sol](https://github.com/fisherman/sol)
+* [jorgebucaran/fish-sol](https://github.com/jorgebucaran/fish-sol) - Simple prompt [archived].


### PR DESCRIPTION
Some *fisherman* related repo names were changed, so the current links work until someone takes again the *fisherman* name. These outdated links were updated.

**Spacefish** added to the prompt package section.